### PR TITLE
Update Trouble shortcuts in init.lua

### DIFF
--- a/.config/nvim/init.lua
+++ b/.config/nvim/init.lua
@@ -1545,9 +1545,9 @@ vim.diagnostic.config({
 	virtual_text = true,
 })
 
-vim.keymap.set('n', '<leader>xx', ':TroubleToggle<cr>', {desc = "Diagnostics list"})
-vim.keymap.set('n', '<leader>xl', ':lopen<cr>', {desc = "Location list"})
-vim.keymap.set('n', '<leader>xq', ':copen<cr>', {desc = "Quickfix list"})
+vim.keymap.set('n', '<leader>xx', ':Trouble diagnostics toggle<cr>', {desc = "Diagnostics list"})
+vim.keymap.set('n', '<leader>xl', ':Trouble loclist toggle<cr>', {desc = "Location list"})
+vim.keymap.set('n', '<leader>xq', ':Trouble qflist toggle<cr>', {desc = "Quickfix list"})
 vim.keymap.set('n', '<leader>xn', function()
 	vim.diagnostic.goto_next({float = false, wrap = false})
 end, {desc = "Next diagnostic"})


### PR DESCRIPTION
I've copied SO MUCH from this file that I feel like I should maybe contribute.

Shortcuts copied from https://github.com/folke/trouble.nvim

Although since you're using lazy.nvim, you might prefer the https://github.com/folke/trouble.nvim?tab=readme-ov-file#-installation instructions.